### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/atlasdcat/mapper.py
+++ b/src/atlasdcat/mapper.py
@@ -58,6 +58,7 @@ import datetime as dt
 import time
 from typing import Any, Dict, List, Optional
 import uuid
+from urllib.parse import urlparse
 
 from datacatalogtordf import (
     Catalog,
@@ -297,9 +298,15 @@ class AtlasDcatMapper:
         self._dataset_uri_template = dataset_uri_template
         self._distribution_uri_template = distribution_uri_template
         self._attr_mapping = attr_mapping if attr_mapping is not None else {}
+
+        parsed_endpoint = urlparse(glossary_client.endpoint_url)
+        host = parsed_endpoint.hostname or ""
+        purview_detected = host == "purview.azure.com" or host.endswith(".purview.azure.com")
+
         self._is_purview = (
-            is_purview is None and "purview.azure.com" in glossary_client.endpoint_url
-        ) or (is_purview is not None and is_purview)
+            (is_purview is None and purview_detected)
+            or (is_purview is not None and is_purview)
+        )
         self._include_approved_only = include_approved_only and is_purview
         self._glossary: Optional[Dict] = None
         self._tmp_glossary_terms: List = []


### PR DESCRIPTION
Potential fix for [https://github.com/Informasjonsforvaltning/atlasdcat/security/code-scanning/1](https://github.com/Informasjonsforvaltning/atlasdcat/security/code-scanning/1)

In general terms, the fix is to stop treating the URL as an opaque string when deciding whether it is a Purview endpoint. Instead, parse the URL and inspect its hostname, then compare the hostname against the expected Purview domain pattern. This avoids accidentally matching `purview.azure.com` in the path, query, username, or an unrelated host like `notpurview.azure.com.evil.com`.

The best targeted fix here is:

1. Parse `glossary_client.endpoint_url` with `urllib.parse.urlparse`.
2. Extract the `hostname` from the parsed result.
3. Consider the endpoint a Purview instance if and only if the hostname is exactly `purview.azure.com` or ends with `.purview.azure.com` (to allow subdomains such as regional endpoints like `foo.purview.azure.com` if needed).
4. Use this boolean in place of the substring expression in the `self._is_purview` assignment.
5. Add the necessary import for `urlparse` from Python’s standard library (`urllib.parse`) at the top of `src/atlasdcat/mapper.py`.

Concretely, in `__init__` of `AtlasDcatMapper` (around lines 290–303), we replace:

```py
self._is_purview = (
    is_purview is None and "purview.azure.com" in glossary_client.endpoint_url
) or (is_purview is not None and is_purview)
```

with code that first parses the endpoint URL into `parsed_endpoint`, extracts `host = parsed_endpoint.hostname`, and then computes `purview_detected` as `host == "purview.azure.com" or (host is not None and host.endswith(".purview.azure.com"))`. Then:

```py
self._is_purview = (
    (is_purview is None and purview_detected)
    or (is_purview is not None and is_purview)
)
```

This preserves the original behavior’s intent: if `is_purview` is explicitly provided, it wins; otherwise we auto‑detect based on the (now correctly inspected) host. The only new import needed is `from urllib.parse import urlparse`, which we add alongside the other imports at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
